### PR TITLE
Store day night mode preference

### DIFF
--- a/underdocs-renderer/src/main/kotlin/underdocs/renderer/output/html/render/page/PageRenderer.kt
+++ b/underdocs-renderer/src/main/kotlin/underdocs/renderer/output/html/render/page/PageRenderer.kt
@@ -67,10 +67,16 @@ class PageRenderer(
                     .with(
                         UnescapedText(
                             """
-                                const isNightModePreferred = () => window.matchMedia?.('(prefers-color-scheme: dark)').matches;
-
+                                const getPreferredTheme = () => {
+                                  if (localStorage.getItem('underdocs_theme') === null) {
+                                    return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'night' : 'day';
+                                  }
+                                
+                                  return localStorage.getItem('underdocs_theme');
+                                }
+                                
                                 (function setPreferredTheme() {
-                                  if (isNightModePreferred()) {
+                                  if (getPreferredTheme() === 'night') {
                                     document.body.classList.add('night');
                                   }
                                 })();
@@ -107,21 +113,21 @@ class PageRenderer(
                         .with(
                             UnescapedText(
                                 """
-                                        (function renderMathElements() {
-                                              document.addEventListener('DOMContentLoaded', function () {
-                                                const mathElements = Array.from(document.getElementsByClassName('katex-inline'))
-                                                    .concat(Array.from(document.getElementsByClassName('katex-block')));
-                                                
-                                                console.log(mathElements.length)
-
-                                                mathElements.forEach(element => {
-                                                    katex.render(element.textContent, element, { 
-                                                        throwOnError: false,
-                                                        displayMode: element.classList.contains('katex-block'), 
-                                                    });
+                                    (function renderMathElements() {
+                                          document.addEventListener('DOMContentLoaded', function () {
+                                            const mathElements = Array.from(document.getElementsByClassName('katex-inline'))
+                                                .concat(Array.from(document.getElementsByClassName('katex-block')));
+                                            
+                                            console.log(mathElements.length)
+    
+                                            mathElements.forEach(element => {
+                                                katex.render(element.textContent, element, { 
+                                                    throwOnError: false,
+                                                    displayMode: element.classList.contains('katex-block'), 
                                                 });
-                                               })
-                                        })();
+                                            });
+                                           })
+                                    })();
                                 """.trimIndent()
                             )
                         ),
@@ -129,17 +135,23 @@ class PageRenderer(
                         .with(
                             UnescapedText(
                                 """
-                                          (function setNightModeButton() {
-                                            const nightModeButton = document.querySelector("#night-mode-button");
-                                    
-                                            if (isNightModePreferred()) {
-                                              nightModeButton.checked = true;
-                                            }
-                                            
-                                            nightModeButton.addEventListener('change', function () {
-                                              document.body.classList.toggle('night');
-                                            })
-                                          })();
+                                    (function setNightModeButton() {
+                                        const nightModeButton = document.querySelector("#night-mode-button");
+                                        
+                                        if (getPreferredTheme() === 'night') {
+                                          nightModeButton.checked = true;
+                                        }
+                                        
+                                        nightModeButton.addEventListener('change', function () {
+                                          document.body.classList.toggle('night');
+                                          
+                                          if (nightModeButton.checked === false) {
+                                            localStorage.setItem('underdocs_theme', 'day');
+                                          } else {
+                                            localStorage.setItem('underdocs_theme', 'night');
+                                          }
+                                        })
+                                    })();
                                 """.trimIndent()
                             )
                         )

--- a/underdocs-renderer/src/main/kotlin/underdocs/renderer/output/html/render/page/PageRenderer.kt
+++ b/underdocs-renderer/src/main/kotlin/underdocs/renderer/output/html/render/page/PageRenderer.kt
@@ -67,17 +67,27 @@ class PageRenderer(
                     .with(
                         UnescapedText(
                             """
-                                const getPreferredTheme = () => {
-                                  if (localStorage.getItem('underdocs_theme') === null) {
-                                    return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'night' : 'day';
-                                  }
+                                const UnderdocsTheme = Object.freeze({
+                                  DAY: 'day',
+                                  NIGHT: 'night',
+                                  KEY: 'underdocs_theme'
+                                });
                                 
-                                  return localStorage.getItem('underdocs_theme');
+                                const isNightModePreferred = () => window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+                                
+                                const getPreferredTheme = () => {
+                                  const savedTheme = localStorage.getItem(UnderdocsTheme.KEY);
+                                  
+                                  if (savedTheme === null) {
+                                    return isNightModePreferred() ? UnderdocsTheme.NIGHT : UnderdocsTheme.DAY;
+                                  }
+                            
+                                  return savedTheme;
                                 }
                                 
                                 (function setPreferredTheme() {
-                                  if (getPreferredTheme() === 'night') {
-                                    document.body.classList.add('night');
+                                  if (getPreferredTheme() === UnderdocsTheme.NIGHT) {
+                                    document.body.classList.add(UnderdocsTheme.NIGHT);
                                   }
                                 })();
                             """.trimIndent()
@@ -138,18 +148,15 @@ class PageRenderer(
                                     (function setNightModeButton() {
                                         const nightModeButton = document.querySelector("#night-mode-button");
                                         
-                                        if (getPreferredTheme() === 'night') {
+                                        if (getPreferredTheme() === UnderdocsTheme.NIGHT) {
                                           nightModeButton.checked = true;
                                         }
                                         
                                         nightModeButton.addEventListener('change', function () {
-                                          document.body.classList.toggle('night');
+                                          document.body.classList.toggle(UnderdocsTheme.NIGHT);
                                           
-                                          if (nightModeButton.checked === false) {
-                                            localStorage.setItem('underdocs_theme', 'day');
-                                          } else {
-                                            localStorage.setItem('underdocs_theme', 'night');
-                                          }
+                                          const themeChoice = nightModeButton.checked ? UnderdocsTheme.NIGHT : UnderdocsTheme.DAY;
+                                          localStorage.setItem(UnderdocsTheme.KEY, themeChoice);
                                         })
                                     })();
                                 """.trimIndent()


### PR DESCRIPTION
The preferred theme is stored in the localStorage, if not use the one preferred by the device. If there is none, use default "Day" mode.
Small refactor on the indentations.

Closes #33 